### PR TITLE
fix: testing delay before processing preview environment

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,6 +74,7 @@ def main():
             if app['metadata']['annotations'].get('preview_environment') == 'true':
                 logger.info(f'OK. This app has the annotation preview_environment == true : {app["metadata"]["name"]}')
                 if app['metadata']['annotations']['head_sha'] not in commits_processed:
+                    time.sleep(15)
                     # Check if the application was created by an ApplicationSet
                     owner_refs = app['metadata']['ownerReferences']
                     appset_created = any(

--- a/main.py
+++ b/main.py
@@ -74,7 +74,7 @@ def main():
             if app['metadata']['annotations'].get('preview_environment') == 'true':
                 logger.info(f'OK. This app has the annotation preview_environment == true : {app["metadata"]["name"]}')
                 if app['metadata']['annotations']['head_sha'] not in commits_processed:
-                    time.sleep(15)
+                    time.sleep(30)
                     # Check if the application was created by an ApplicationSet
                     owner_refs = app['metadata']['ownerReferences']
                     appset_created = any(


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a 30-second delay before processing preview environments to ensure proper handling of new applications.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add delay before processing preview environments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.py

- Added a 30-second delay before processing preview environments.



</details>


  </td>
  <td><a href="https://github.com/GlueOps/pull-request-bot/pull/46/files#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

